### PR TITLE
Add a custom training menu for SSF2X with Auto-Block and Stage-Select

### DIFF
--- a/fbneo-training-mode.lua
+++ b/fbneo-training-mode.lua
@@ -185,9 +185,6 @@ local defaultconfig = {
 	hitbox = {
 		enabled = true,
 	},
-	custom = {
-		stage_selector = -1,
-	},
 }
 
 local config = defaultconfig
@@ -592,11 +589,6 @@ recording = {
 	swapplayers = true,
 	replayP1 = false,
 	replayP2 = true,
-}
-
-custom = {
-	stage_selector = config.custom.stage_selector,
-
 }
 
 ----------------------------------------------

--- a/fbneo-training-mode.lua
+++ b/fbneo-training-mode.lua
@@ -185,6 +185,9 @@ local defaultconfig = {
 	hitbox = {
 		enabled = true,
 	},
+	custom = {
+		stage_selector = -1,
+	},
 }
 
 local config = defaultconfig
@@ -589,6 +592,11 @@ recording = {
 	swapplayers = true,
 	replayP1 = false,
 	replayP2 = true,
+}
+
+custom = {
+	stage_selector = config.custom.stage_selector,
+
 }
 
 ----------------------------------------------

--- a/games/ssf2xjr1/guipages.lua
+++ b/games/ssf2xjr1/guipages.lua
@@ -1,0 +1,86 @@
+assert(rb,"Run fbneo-training-mode.lua")
+
+guicustompage = {
+	title = {
+		text = "Super Street Fighter 2X Settings",
+		x = interactivegui.boxxlength/2 - (#"Super Street Fighter 2X Settings")*2,
+		y = 1,
+	},
+	guielements.leftarrow,
+	guielements.rightarrow,
+	{
+		text = "Stage selector",
+		x = 8,
+		y = 40,
+		olcolour = "black",
+		info = {
+			"Background stage selection",
+			"Must be changed on player select screen, before selecting character."
+		},
+		func =	function()
+				-- CIG("guicustompage", stage_selector)
+				-- changeConfig("ssf2xjr1","stage_selector", stage_selector, ssf2xjr1)
+				-- modulevars.constants.stage_selector = stage_selector+1
+				stage_selector = stage_selector + 1
+				if stage_selector >= 0xf then
+					stage_selector=-1
+				end
+				changeConfig("custom","stage_selector", stage_selector, custom)
+				
+			end,
+		autofunc = 	function(this)
+						if stage_selector == -1 then
+							this.text = "Select stage"
+							this.x = 8
+						elseif stage_selector == 0 then
+							this.text = "Stage: Japan (Ryu)"
+							this.x = 8
+						elseif stage_selector == 1 then
+							this.text = "Stage: Japan (Honda)"
+							this.x = 8
+						elseif stage_selector == 2 then
+							this.text = "Stage: Brazil (Blanka)"
+							this.x = 8
+						elseif stage_selector == 3 then
+							this.text = "Stage: USA (Guile)"
+							this.x = 8
+						elseif stage_selector == 4 then
+							this.text = "Stage: USA (Ken)"
+							this.x = 8
+						elseif stage_selector == 5 then
+							this.text = "Stage: China (Chun-Li)"
+							this.x = 8
+						elseif stage_selector == 6 then
+							this.text = "Stage: USSR (Zangief)"
+							this.x = 8
+						elseif stage_selector == 7 then
+							this.text = "Stage: India (Dhalsim)"
+							this.x = 8
+						elseif stage_selector == 8 then
+							this.text = "Stage: Thailand (Dictator)"
+							this.x = 8
+						elseif stage_selector == 9 then
+							this.text = "Stage: Thailand (Sagat)"
+							this.x = 8
+						elseif stage_selector == 0xa then
+							this.text = "Stage: USA (Boxer)"
+							this.x = 8
+						elseif stage_selector == 0xb then
+							this.text = "Stage: Spain (Claw)"
+							this.x = 8
+						elseif stage_selector == 0xc then
+							this.text = "Stage: England (Cammy)"
+							this.x = 8
+						elseif stage_selector == 0xd then
+							this.text = "Stage: Mexico (T.Hawk)"
+							this.x = 8
+						elseif stage_selector == 0xe then
+							this.text = "Stage: HongKong (Fei-Long)"
+							this.x = 8
+						elseif stage_selector == 0xf then
+							this.text = "Stage: Jamaica (DeeJay)"
+							this.x = 8
+						end
+					end
+	},
+}

--- a/games/ssf2xjr1/guipages.lua
+++ b/games/ssf2xjr1/guipages.lua
@@ -9,7 +9,7 @@ guicustompage = {
 	guielements.leftarrow,
 	guielements.rightarrow,
 	{
-		text = "Stage selector",
+		text = "Select stage",
 		x = 8,
 		y = 40,
 		olcolour = "black",
@@ -18,19 +18,14 @@ guicustompage = {
 			"Must be changed on player select screen, before selecting character."
 		},
 		func =	function()
-				-- CIG("guicustompage", stage_selector)
-				-- changeConfig("ssf2xjr1","stage_selector", stage_selector, ssf2xjr1)
-				-- modulevars.constants.stage_selector = stage_selector+1
 				stage_selector = stage_selector + 1
-				if stage_selector >= 0xf then
+				if stage_selector > 0xf then
 					stage_selector=-1
 				end
-				changeConfig("custom","stage_selector", stage_selector, custom)
-				
 			end,
 		autofunc = 	function(this)
 						if stage_selector == -1 then
-							this.text = "Select stage"
+							this.text = "Select stage: Disabled"
 							this.x = 8
 						elseif stage_selector == 0 then
 							this.text = "Stage: Japan (Ryu)"
@@ -82,5 +77,34 @@ guicustompage = {
 							this.x = 8
 						end
 					end
+	},
+	{
+		text = "AutoBlock",
+		x = 8,
+		y = 60,
+		olcolour = "black",
+		info = {
+			"Control auto-block on P2",
+			"Can be Disabled, block everything, block only ground attacks, block auto or block random."
+		},
+		func =	function()
+				autoblock_selector = autoblock_selector + 1
+				if autoblock_selector > 3 then
+					autoblock_selector = -1
+				end
+			end,
+		autofunc = function(this)
+				if autoblock_selector == -1 then
+					this.text = "AutoBlock (P2): Disabled"
+				elseif autoblock_selector == 0 then
+					this.text = "AutoBlock (P2): Block everything"
+				elseif autoblock_selector == 1 then
+					this.text = "AutoBlock (P2): Block ground attacks"
+				elseif autoblock_selector == 2 then
+					this.text = "AutoBlock (P2): Block auto"
+				elseif autoblock_selector == 3 then
+					this.text = "AutoBlock (P2): Block random"
+				end
+			end,
 	},
 }

--- a/games/ssf2xjr1/guipages.lua
+++ b/games/ssf2xjr1/guipages.lua
@@ -2,8 +2,8 @@ assert(rb,"Run fbneo-training-mode.lua")
 
 guicustompage = {
 	title = {
-		text = "Super Street Fighter 2X Settings",
-		x = interactivegui.boxxlength/2 - (#"Super Street Fighter 2X Settings")*2,
+		text = "Super Street Fighter 2X - pof's Training Mode Settings",
+		x = interactivegui.boxxlength/2 - (#"Super Street Fighter 2X - pof's Training Mode Settings")*2,
 		y = 1,
 	},
 	guielements.leftarrow,
@@ -26,55 +26,38 @@ guicustompage = {
 		autofunc = 	function(this)
 						if stage_selector == -1 then
 							this.text = "Select stage: Disabled"
-							this.x = 8
 						elseif stage_selector == 0 then
 							this.text = "Stage: Japan (Ryu)"
-							this.x = 8
 						elseif stage_selector == 1 then
 							this.text = "Stage: Japan (Honda)"
-							this.x = 8
 						elseif stage_selector == 2 then
 							this.text = "Stage: Brazil (Blanka)"
-							this.x = 8
 						elseif stage_selector == 3 then
 							this.text = "Stage: USA (Guile)"
-							this.x = 8
 						elseif stage_selector == 4 then
 							this.text = "Stage: USA (Ken)"
-							this.x = 8
 						elseif stage_selector == 5 then
 							this.text = "Stage: China (Chun-Li)"
-							this.x = 8
 						elseif stage_selector == 6 then
 							this.text = "Stage: USSR (Zangief)"
-							this.x = 8
 						elseif stage_selector == 7 then
 							this.text = "Stage: India (Dhalsim)"
-							this.x = 8
 						elseif stage_selector == 8 then
 							this.text = "Stage: Thailand (Dictator)"
-							this.x = 8
 						elseif stage_selector == 9 then
 							this.text = "Stage: Thailand (Sagat)"
-							this.x = 8
 						elseif stage_selector == 0xa then
 							this.text = "Stage: USA (Boxer)"
-							this.x = 8
 						elseif stage_selector == 0xb then
 							this.text = "Stage: Spain (Claw)"
-							this.x = 8
 						elseif stage_selector == 0xc then
 							this.text = "Stage: England (Cammy)"
-							this.x = 8
 						elseif stage_selector == 0xd then
 							this.text = "Stage: Mexico (T.Hawk)"
-							this.x = 8
 						elseif stage_selector == 0xe then
 							this.text = "Stage: HongKong (Fei-Long)"
-							this.x = 8
 						elseif stage_selector == 0xf then
 							this.text = "Stage: Jamaica (DeeJay)"
-							this.x = 8
 						end
 					end
 	},
@@ -84,7 +67,7 @@ guicustompage = {
 		y = 60,
 		olcolour = "black",
 		info = {
-			"Control auto-block on P2",
+			"Control guard / auto-block on P2",
 			"Can be Disabled, block everything, block only ground attacks, block auto or block random."
 		},
 		func =	function()
@@ -107,4 +90,30 @@ guicustompage = {
 				end
 			end,
 	},
+	{
+		text = "Stun/Dizzy",
+		x = 8,
+		y = 80,
+		olcolour = "black",
+		info = {
+			"Control Stun/Dizzy",
+			"Can be normal, off (never dizzy) or on (always dizzy)"
+		},
+		func =	function()
+				dizzy_selector = dizzy_selector + 1
+				if dizzy_selector > 2 then
+					dizzy_selector = -1
+				end
+			end,
+		autofunc = function(this)
+				if dizzy_selector == -1 then
+					this.text = "Stun/Dizzy (P2): Normal"
+				elseif dizzy_selector == 0 then
+					this.text = "Stun/Dizzy (P2): Off (never dizzy)"
+				elseif dizzy_selector == 1 then
+					this.text = "Stun/Dizzy (P2): On (always dizzy)"
+				end
+			end,
+	},
+
 }

--- a/games/ssf2xjr1/ssf2xjr1.lua
+++ b/games/ssf2xjr1/ssf2xjr1.lua
@@ -358,6 +358,23 @@ local autoBlock = function()
 
 end
 
+dizzy_selector = -1
+local p2DizzyControl = function()
+
+	local dizzy = 0
+	if dizzy_selector == -1 then
+		return
+	end
+
+	if dizzy_selector == 1 then
+		dizzy = 0x40
+	end
+
+	ww(0xFF88AA, dizzy) -- timeout
+	ww(0xFF88AC, dizzy) -- damage
+
+end
+
 function Run() -- runs every frame
 
 	-- attacker state (ff8451 or +0x400 for p2): 0 idle, 2 crouching, 4 jumping, 10 doing a normal attack or throw, 12 on hitstun (doing an special attack)
@@ -369,8 +386,9 @@ function Run() -- runs every frame
 	p1inputs = rw(0xFF87E0)
 
 	infiniteTime()
+	autoBlock()
 	neverEnd()
 	stageSelect()
-	autoBlock()
+	p2DizzyControl()
 	prev_p1action = p1action
 end

--- a/games/ssf2xjr1/ssf2xjr1.lua
+++ b/games/ssf2xjr1/ssf2xjr1.lua
@@ -252,10 +252,16 @@ local getDistanceBetweenPlayers = function()
 	return distance
 end
 
+autoblock_selector = -1
 local forceblock = false
 local prev_p1action = 0
 local inputs_at_jumpstart = 0
+local autoblock_skip_counter = 60
 local autoBlock = function()
+
+	if autoblock_selector == -1 then
+		return
+	end
 
 	local DEBUG=false
 
@@ -270,6 +276,16 @@ local autoBlock = function()
 
 	-- if opponent is ground attacking, ground block
 	if (p1action == 10 or p1action == 12) and distance < 265 then
+
+		if autoblock_selector == 2 or autoblock_selector == 3 then
+			autoblock_skip_counter = autoblock_skip_counter -1
+			if autoblock_skip_counter == 0 then
+				autoblock_skip_counter = 60
+			end
+			if autoblock_skip_counter > 40 then
+				return
+			end
+		end
 
 		local p1crouching = player1Crouching()
 		if playerOneFacingLeft() and p1crouching then
@@ -290,7 +306,18 @@ local autoBlock = function()
 
 	-- block jump attacks
 	local p1attacking = false
-	if p1action == 4 and distance < 265 then
+	if autoblock_selector ~= 1 and autoblock_selector ~= 2 and p1action == 4 and distance < 265 then
+
+		if autoblock_selector == 3 then
+			autoblock_skip_counter = autoblock_skip_counter -1
+			if autoblock_skip_counter == 0 then
+				autoblock_skip_counter = 60
+			end
+			if autoblock_skip_counter > 30 then
+				return
+			end
+		end
+
 		local p1buttons = bit.band(p1inputs, 0x000F)
 		if prev_p1action ~= 4 then
 			inputs_at_jumpstart = p1inputs-p1buttons

--- a/games/ssf2xjr1/ssf2xjr1.lua
+++ b/games/ssf2xjr1/ssf2xjr1.lua
@@ -215,8 +215,11 @@ local neverEnd = function()
 	end
 end
 
+stage_selector = -1
 local stageSelect = function()
-	local stage_selector = 0x0c -- cammy
+	if stage_selector == -1 then
+		return
+	end
 	if rb(0xff8008) == 0x04 then
 		wb(0xff8c4f,stage_selector)
 	end


### PR DESCRIPTION
- Auto Block allows to set 4 different guard modes for the P2 dummy: block everything, block ground attacks, block auto, block random
- Stage selector allows to choose the background stage that will be used.
- Added also an option to control Dizzy: normal, always dizzy, never dizzy. This should fix #42 .