### PR TITLE
SSF2X: Improved training mode with options for auto-reversal

### DIFF
--- a/fbneo-training-mode.lua
+++ b/fbneo-training-mode.lua
@@ -1529,7 +1529,7 @@ local logRecording = function()
 
 end
 
-local togglePlayBack = function(bool, vargs)
+togglePlayBack = function(bool, vargs)
 	if interactivegui.movehud then return end
 	
 	if vargs then vargs.playback = false end

--- a/games/ssf2xjr1/character_specific.lua
+++ b/games/ssf2xjr1/character_specific.lua
@@ -23,7 +23,7 @@ characters =
     }
 
 for i = 1, #characters do
-  character_specific[characters[i]] = { specials = {}}
+  character_specific[characters[i]] = { specials = {}, throw = {}}
 end
 ------------------------------------------------------------------------------
 character_specific.blanka.specials = {
@@ -34,6 +34,7 @@ character_specific.blanka.specials = {
     },
 	id = 0x00,
 	strength_set = 1,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -44,6 +45,7 @@ character_specific.blanka.specials = {
     },
 	id = 0x04,
 	strength_set = 1,
+	reversal = true,
     input = { {"down", "h_charge"}, {"up"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -54,6 +56,7 @@ character_specific.blanka.specials = {
     },
 	id = 0x06,
 	strength_set = 1,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -67,6 +70,7 @@ character_specific.blanka.specials = {
     },
 	id = 0x02,
 	strength_set = 1,
+	reversal = true,
     input = {{}},
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -76,6 +80,7 @@ character_specific.blanka.specials = {
     },
 	id = 0x0A,
 	strength_set = 0,
+	reversal = true,
     input = { {"forward"} },
     input_variations = {{"LK", "MK", "HK"}},
   },
@@ -85,6 +90,7 @@ character_specific.blanka.specials = {
     },
 	id = 0x0C,
 	strength_set = 0,
+	reversal = true,
     input = { {"back"} },
     input_variations = {{"LK", "MK", "HK"}},
   },
@@ -95,10 +101,12 @@ character_specific.blanka.specials = {
     },
 	id = 0x08,
 	strength_set = 0,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"}, {"back"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   }
 }
+character_specific.blanka.throw = {"HP"}
 ----------------------------------------------------------------------------
 character_specific.boxer.specials = {
 	{
@@ -111,6 +119,7 @@ character_specific.boxer.specials = {
     },
 	id = 0x00,
 	strength_set = 1,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -124,6 +133,7 @@ character_specific.boxer.specials = {
     },
 	id = 0x02,
 	strength_set = 1,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -134,6 +144,7 @@ character_specific.boxer.specials = {
     },
 	id = 0x06,
 	strength_set = 1,
+	reversal = true,
     input = { {"down", "v_charge"}, {"up"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -147,6 +158,7 @@ character_specific.boxer.specials = {
     },
 	id = 0x0A,
 	strength_set = 1,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward", "down"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -160,10 +172,44 @@ character_specific.boxer.specials = {
     },
 	id = 0x0C,
 	strength_set = 1,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward", "down"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
-   --~ 0001 - One
+  {
+   name = "TAP", -- Modified to fit makeReversalSettingsButtons()
+   memory_map = {
+    {0xB6, 0001} -- More values need to be added
+    },
+	id = 0x04,
+	strength_set = -1,
+	reversal = true,
+    input = {{}},
+    input_variations = {{"1"},{"2"},{"3"},{"4"},{"5"},{"6"},{"7"},{"Final"}},
+   },
+   {
+    name = "TAP Punch",
+    memory_map = {
+      {0xB6, 0001} -- More values need to be added
+      },
+	id = 0x04,
+	strength_set = -1,
+	reversal = false,
+    input = {{}},
+    input_variations = {{"LP", "MP", "HP"}},
+   },
+   {
+    name = "TAP Kick",
+    memory_map = {
+      {0xB8, 0001} -- More values need to be added
+      },
+	id = 0x04,
+	strength_set = -1,
+	reversal = false,
+    input = {{}},
+    input_variations = {{"LK", "MK", "HK"}},
+   },
+  --~ 0001 - One
   --~ 0121 - Two
   --~ 0241 - Three
   --~ 0481 - Four
@@ -171,36 +217,20 @@ character_specific.boxer.specials = {
   --~ 1441 - Six
   --~ 1921 - Seven
   --~ 2401 - Final
-  -- TAP is gonna be hard because it should be negative edge I guess
+  -- MCMic : TAP is gonna be hard because it should be negative edge I guess
   {
-   name = "TAP",
-   memory_map = {
-    {0xB6, 0001} -- A voir
-    },
-	id = 0x04,
-	strength_set = 0,
-    input = {{}},
-   input_variations = {{"LP", "MP", "HP"}},
-	},
-  --~ {
-    --~ name = "TAP Kick",
-    --~ memory_map = {
-      --~ {0xB8, 0001} -- A voir
-    --~ },
-    --~ input = {{}},
-    --~ input_variations = {{"LK", "MK", "HK"}},
-  --~ },
-  {
-    name = "Crazy Buffalo", -- Voir comment intégrer les différentes phases de la super ?
+    name = "Crazy Buffalo",
     memory_map = {
       {0xD4, 0x0A}
     },
 	id = 0x08,
 	strength_set = 0,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"}, {"back"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}, {"LK"}, {"MK"}, {"HK"}},
   }
 }
+character_specific.boxer.throw = {"MP","HP"}
 ----------------------------------------------------------------------------
 character_specific.cammy.specials = {
 	{
@@ -210,6 +240,7 @@ character_specific.cammy.specials = {
     },
 	id = 0x00,
 	strength_set = 2,
+	reversal = true,
     input = { {"forward"}, {"down"}, {"forward", "down"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -220,6 +251,7 @@ character_specific.cammy.specials = {
     },
 	id = 0x02,
 	strength_set = 2,
+	reversal = true,
     input = { {"down"}, {"forward", "down"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -230,16 +262,18 @@ character_specific.cammy.specials = {
     },
 	id = 0x04,
 	strength_set = 2,
+	reversal = true,
     input = { {"back"}, {"back", "down"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
   {
-    name = "Hooligan Combination", -- Compléter pour avoir les deux variations
+    name = "Hooligan Combination",
     memory_map = {
       {0xA9, 0x06} -- buggy
     },
 	id = 0x08,
 	strength_set = 2,
+	reversal = true,
     input = { {"back"}, {"down"}, {"forward", "down"}, {"up", "forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -250,10 +284,12 @@ character_specific.cammy.specials = {
     },
 	id = 0x06,
 	strength_set = 0,
+	reversal = true,
     input = { {"down"}, {"forward", "down"}, {"forward"}, {"down"}, {"forward", "down"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   }
 }
+character_specific.cammy.throw = {"MP", "HP", "MK", "HK"}
 ------------------------------------------------------------------------------
 character_specific.chunli.specials = {
 	{
@@ -262,7 +298,8 @@ character_specific.chunli.specials = {
       {0xB0, 0x06}
     },
 	id = 0x00,
-	strength_set = 2,
+	strength_set = 1,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -276,19 +313,21 @@ character_specific.chunli.specials = {
     },
 	id = 0x02,
 	strength_set = 1,
+	reversal = true,
     input = {{}},
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
   {
     name = "Kikouken",
     memory_map = {
-      {0x80, 0x06}, -- Ne fonctionne pas
+      {0x80, 0x06}, -- Doesn't work
       {0x81, 0x00},
       {0x82, 0x01},
       {0x83, 0x01}
     },
 	id = 0x04,
 	strength_set = 2,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -299,6 +338,7 @@ character_specific.chunli.specials = {
     },
 	id = 0x06,
 	strength_set = 2,
+	reversal = true,
     input = { {"down", "h_charge"}, {"up"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -309,10 +349,12 @@ character_specific.chunli.specials = {
     },
 	id = 0x08,
 	strength_set = 0,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"}, {"back"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   }
 }
+character_specific.chunli.throw = {"MP","HP"}
 ----------------------------------------------------------------------------------
 character_specific.claw.specials = {
 	{
@@ -322,6 +364,7 @@ character_specific.claw.specials = {
     },
 	id = 0x00,
 	strength_set = 2,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -332,6 +375,7 @@ character_specific.claw.specials = {
     },
 	id = 0x02,
 	strength_set = 2,
+	reversal = true,
     input = { {"down", "h_charge"}, {"up"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -342,6 +386,7 @@ character_specific.claw.specials = {
     },
 	id = 0x06,
 	strength_set = 2,
+	reversal = true,
     input = { {"down", "h_charge"}, {"up"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -352,6 +397,7 @@ character_specific.claw.specials = {
     },
 	id = 0x0C,
 	strength_set = 2,
+	reversal = true,
     input = { {"down", "back", "h_charge"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -361,6 +407,7 @@ character_specific.claw.specials = {
     input = {{}},
 	id = 0x04,
 	strength_set = 0,
+	reversal = true,
     input_variations = {{"LP", "MP", "HP"}},
   },
   {
@@ -369,6 +416,7 @@ character_specific.claw.specials = {
     input = {{}},
 	id = 0x08,
 	strength_set = 0,
+	reversal = true,
     input_variations = {{"LK", "MK", "HK"}},
   },
   {
@@ -378,10 +426,12 @@ character_specific.claw.specials = {
     },
 	id = 0x0A,
 	strength_set = 0,
+	reversal = true,
     input = { {"down", "h_charge"}, {"forward"}, {"back"}, {"up"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   }
 }
+character_specific.claw.throw = {"MP","HP"}
 ---------------------------------------------------------------------------------
 character_specific.deejay.specials = {
   {
@@ -391,6 +441,7 @@ character_specific.deejay.specials = {
     },
 	id = 0x00,
 	strength_set = 2,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -401,6 +452,7 @@ character_specific.deejay.specials = {
     },
 	id = 0x02,
 	strength_set = 2,
+	reversal = true,
     input = { {"down", "h_charge"}, {"up"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -411,6 +463,7 @@ character_specific.deejay.specials = {
     },
 	id = 0x04,
 	strength_set = 2,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -421,6 +474,7 @@ character_specific.deejay.specials = {
     },
 	id = 0x06,
 	strength_set = 2,
+	reversal = true,
     input = { {"down", "h_charge"}, {"up"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -431,10 +485,12 @@ character_specific.deejay.specials = {
     },
 	id = 0x08,
 	strength_set = 0,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"}, {"back"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   }
 }
+character_specific.deejay.throw = {"MP","HP","MK","HK"}
 --------------------------------------------------------------------------------
 character_specific.dhalsim.specials = {
   {
@@ -444,6 +500,7 @@ character_specific.dhalsim.specials = {
     },
 	id = 0x00,
 	strength_set = 2,
+	reversal = true,
     input = { {"down"}, {"forward", "down"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -454,6 +511,7 @@ character_specific.dhalsim.specials = {
     },
 	id = 0x02,
 	strength_set = 2,
+	reversal = true,
     input = { {"back"}, {"back", "down"}, {"down"}, {"forward", "down"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -464,49 +522,55 @@ character_specific.dhalsim.specials = {
     },
 	id = 0x08,
 	strength_set = 2,
+	reversal = true,
     input = { {"back"}, {"forward", "down"}, {"down"}, { "forward", "down"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
    {
     name = "Yoga Teleport", -- Modified to fit makeReversalSettingsButtons()
     memory_map = {
-      {0xE0, 0x06}
+      {0xE0, 0x06} -- More values need to be added
     },
 	id = 0x04,
 	strength_set = -1,
+	reversal = true,
     input_variations = {{"F+P"},{"F+K"},{"B+P"},{"B+K"}},
   },
-  --{
-    --name = "Yoga Teleport (Forward)",
-    --memory_map = {
-     -- {0xE0, 0x06} -- Autre valeur à rajouter
-    --},
-	--id = 0x04,
-	--strength_set = 2,
-    --input = { {"forward"}, {"down"}, {"forward", "down"} },
-    --input_variations = {{"LP", "MP", "HP"},{"LK", "MK", "HK"}},
-  --},
-  --{
-   -- name = "Yoga Teleport (Back)",
-    --memory_map = {
-     -- {0xE0, 0x05} -- Autre valeur à rajouter
-    --},
-	--id = 0x04,
-	--strength_set = 2,
-    --input = { {"back"}, {"down"}, {"back", "down"} },
-    --input_variations = {{"LP", "MP", "HP"},{"LK", "MK", "HK"}},
-  --},
+  {
+    name = "Yoga Teleport (Forward)",
+    memory_map = {
+     {0xE0, 0x06} -- More values need to be added (see at the very bottom of the document)
+    },
+	id = 0x04,
+	strength_set = 2,
+	reversal = false,
+    input = { {"forward"}, {"down"}, {"forward", "down"} },
+    input_variations = {{"LP", "MP", "HP"},{"LK", "MK", "HK"}},
+  },
+  {
+    name = "Yoga Teleport (Back)",
+    memory_map = {
+     {0xE0, 0x05} -- More values need to be added
+    },
+	id = 0x04,
+	strength_set = 2,
+	reversal = false,
+    input = { {"back"}, {"down"}, {"back", "down"} },
+    input_variations = {{"LP", "MP", "HP"},{"LK", "MK", "HK"}},
+  },
   {
     name = "Yoga Inferno",
     memory_map = {
-      {0x96, 0x10}
+     {0x96, 0x10}
     },
-	id = 0x06,
-	strength_set = 0,
+    id = 0x06,
+    strength_set = 0,
+	reversal = false,
     input = { {"back"},{"back", "down"},{"down"},{"forward", "down"},{"back"},{"back", "down"},{"down"},{"forward", "down"},{"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   }
 }
+character_specific.dhalsim.throw = {"MP","HP"}
 --------------------------------------------------------------------------------------------------
 character_specific.dictator.specials = {
   {
@@ -516,6 +580,7 @@ character_specific.dictator.specials = {
     },
 	id = 0x00,
 	strength_set = 1,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -526,6 +591,7 @@ character_specific.dictator.specials = {
     },
 	id = 0x02,
 	strength_set = 1,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -536,6 +602,7 @@ character_specific.dictator.specials = {
     },
 	id = 0x04,
 	strength_set = 1,
+	reversal = true,
     input = { {"down", "h_charge"}, {"up"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -546,6 +613,7 @@ character_specific.dictator.specials = {
     },
 	id = 0x06,
 	strength_set = 2,
+	reversal = true,
     input = { {"down", "h_charge"}, {"up"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -556,10 +624,12 @@ character_specific.dictator.specials = {
     },
 	id = 0x08,
 	strength_set = 0,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"}, {"back"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   }
 }
+character_specific.dictator.throw = {"MP","HP"}
 ---------------------------------------------------------------------------------
 character_specific.feilong.specials = {
   {
@@ -570,6 +640,7 @@ character_specific.feilong.specials = {
     },
 	id = 0x00,
 	strength_set = 2,
+	reversal = true,
     input = { {"down"}, {"down", "forward"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -588,6 +659,7 @@ character_specific.feilong.specials = {
     },
 	id = 0x02,
 	strength_set = 2,
+	reversal = true,
     input = { {"back"}, {"down"}, {"down", "back"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -598,6 +670,7 @@ character_specific.feilong.specials = {
     },
 	id = 0x06,
 	strength_set = 2,
+	reversal = true,
     input = { {"back"}, {"down"}, {"forward", "down"}, {"forward", "up"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}} -- only lk works
   },
@@ -608,10 +681,12 @@ character_specific.feilong.specials = {
     },
 	id = 0x04,
 	strength_set = 0,
+	reversal = true,
      input = { {"down"}, {"down", "forward"}, {"forward"}, {"down"}, {"down", "forward"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   }
 }
+character_specific.feilong.throw = {"MP","HP","MK","HK"}
 -------------------------------------------------------------------------------------------
 character_specific.guile.specials = {
   {
@@ -621,6 +696,7 @@ character_specific.guile.specials = {
     },
 	id = 0x00,
 	strength_set = 1,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -631,6 +707,7 @@ character_specific.guile.specials = {
     },
 	id = 0x02,
 	strength_set = 1,
+	reversal = true,
     input = { {"down", "v_charge"}, {"up"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -641,10 +718,12 @@ character_specific.guile.specials = {
     },
 	id = 0x04,
 	strength_set = 0,
+	reversal = true,
     input = { {"down", "v_charge"}, {"forward"}, {"back"}, {"up"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   }
 }
+character_specific.guile.throw = {"MP","HP"}
 ----------------------------------------------------------------------
 character_specific.ehonda.specials = {
   {
@@ -654,6 +733,7 @@ character_specific.ehonda.specials = {
     },
 	id = 0x00,
 	strength_set = 2,
+	reversal = true,
      input = { {"back", "h_charge"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -667,6 +747,7 @@ character_specific.ehonda.specials = {
     },
 	id = 0x02,
 	strength_set = 2,
+	reversal = true,
     input = {{}},
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -677,6 +758,7 @@ character_specific.ehonda.specials = {
     },
 	id = 0x04,
 	strength_set = 2,
+	reversal = true,
     input = { {"down", "h_charge"}, {"up"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -687,20 +769,23 @@ character_specific.ehonda.specials = {
     },
 	id = 0x08,
 	strength_set = 0,
+	reversal = true,
     input = { {"forward"}, {"forward", "down"}, {"down"}, {"back"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
   {
-    name = "Double Headbutt", -- ne s'affiche pas
+    name = "Double Headbutt",
     memory_map = {
       {0x94, 0x0A}
     },
 	id = 0x06,
 	strength_set = 0,
+	reversal = true,
     input = { {"back", "h_charge"}, {"forward"}, {"back"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   }
 }
+character_specific.ehonda.throw = {"MP","HP","HK"}
 -----------------------------------------------------------------------
 character_specific.thawk.specials = {
  {
@@ -709,12 +794,13 @@ character_specific.thawk.specials = {
       {0x8D, 0x04}
     },
 	id = 0x00,
-	strength_set = 2,
+	strength_set = 2, -- Bug
+	reversal = true,
 	input = { {"forward"}, {"down"}, {"down", "forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
   {
-    name = "Mexican Typhoon", -- A voir
+    name = "Mexican Typhoon", -- To be fixed : works only on one side
     memory_map = {
       {0x91,0x04}, -- or 5 if other side
       {0x92,0x06},
@@ -723,19 +809,22 @@ character_specific.thawk.specials = {
     },
 	id = 0x04,
 	strength_set = 2,
+	reversal = true,
     input = {{"back"}}, -- fixme
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
   {
-    name = "Double Typhoon", -- A voir
+    name = "Double Typhoon", -- To be fixed : works only on one side
     memory_map = {
     },
 	id = 0x06,
 	strength_set = 0,
+	reversal = true,
     input = {{}},
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   }
 }
+character_specific.thawk.throw = {"MP","HP","HK"}
 --------------------------------------------------------------------
 character_specific.ken.specials = {
   {
@@ -745,6 +834,7 @@ character_specific.ken.specials = {
     },
 	id = 0x00,
 	strength_set = 2,
+	reversal = true,
     input = { {"down"}, {"down", "forward"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -755,6 +845,7 @@ character_specific.ken.specials = {
     },
 	id = 0x02,
 	strength_set = 2,
+	reversal = true,
     input = { {"down"}, {"down", "back"}, {"back"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -765,6 +856,7 @@ character_specific.ken.specials = {
     },
 	id = 0x04,
 	strength_set = 2,
+	reversal = true,
     input = { {"forward"}, {"down"}, {"down", "forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -775,6 +867,7 @@ character_specific.ken.specials = {
     },
 	id = 0x08,
 	strength_set = 0,
+	reversal = true,
     input = { {"down"}, {"down", "forward"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -785,6 +878,7 @@ character_specific.ken.specials = {
     },
 	id = 0x0A,
 	strength_set = 0,
+	reversal = true,
     input = { {"forward"}, {"down", "forward"}, {"down"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -795,20 +889,23 @@ character_specific.ken.specials = {
     },
 	id = 0x0C,
 	strength_set = 0,
+	reversal = true,
     input = { {"down"}, {"down", "forward"}, {"forward"}, {"down"}, {"down", "forward"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
   {
     name = "Shoryureppa",
     memory_map = {
-      {0xA0, 0x08}
+     {0xA0, 0x08}
     },
 	id = 0x06,
 	strength_set = 0,
+	reversal = false,
     input = { {"down"}, {"down", "forward"}, {"forward"}, {"down"}, {"down", "forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   }
 }
+character_specific.ken.throw = {"MP","HP","MK","HK"}
 ----------------------------------------------------------------------
 character_specific.ryu.specials = {
   {
@@ -818,6 +915,7 @@ character_specific.ryu.specials = {
     },
 	id = 0x00,
 	strength_set = 2,
+	reversal = true,
     input = { {"down"}, {"down", "forward"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -828,6 +926,7 @@ character_specific.ryu.specials = {
     },
 	id = 0x02,
 	strength_set = 2,
+	reversal = true,
     input = { {"down"}, {"down", "back"}, {"back"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -838,6 +937,7 @@ character_specific.ryu.specials = {
     },
 	id = 0x04,
 	strength_set = 2,
+	reversal = true,
     input = { {"forward"}, {"down"}, {"down", "forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -848,6 +948,7 @@ character_specific.ryu.specials = {
     },
 	id = 0x06,
 	strength_set = 2,
+	reversal = true,
     input = { {"back"}, {"back", "forward"}, {"down"}, {"down", "forward"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -858,10 +959,12 @@ character_specific.ryu.specials = {
     },
 	id = 0x08,
 	strength_set = 0,
+	reversal = true,
     input = { {"down"}, {"down", "forward"}, {"forward"}, {"down"}, {"down", "forward"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   }
 }
+character_specific.ryu.throw = {"MP","HP","MK","HK"}
 ----------------------------------------------------------------------------------------
 character_specific.sagat.specials = {
   {
@@ -871,6 +974,7 @@ character_specific.sagat.specials = {
     },
 	id = 0x00,
 	strength_set = 2,
+	reversal = true,
     input = { {"down"}, {"down", "forward"}, {"forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -881,6 +985,7 @@ character_specific.sagat.specials = {
     },
 	id = 0x04,
 	strength_set = 2,
+	reversal = true,
     input = { {"down"}, {"down", "forward"}, {"forward"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -891,6 +996,7 @@ character_specific.sagat.specials = {
     },
 	id = 0x02,
 	strength_set = 2,
+	reversal = true,
    input = { {"forward"}, {"down"}, {"down", "forward"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -901,24 +1007,27 @@ character_specific.sagat.specials = {
     },
 	id = 0x06,
 	strength_set = 2,
+	reversal = true,
     input = { {"down"}, {"forward"}, {"forward", "up"} },
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
   {
     name = "Tiger Genocide",
     memory_map = {
-      {0x9E, 0x0A}
+     {0x9E, 0x0A}
     },
-	id = 0x08,
-	strength_set = 0,
+    id = 0x08,
+    strength_set = 0,
+	reversal = false,
     input = { {"down"}, {"forward", "down"}, {"forward"}, {"down"}, {"forward", "down"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}, {"LK"}, {"MK"}, {"HK"}},
   }
 }
+character_specific.sagat.throw = {"MP","HP"}
 ------------------------------------------------------------------------
 character_specific.zangief.specials = {
   {
-    name = "Spinning Pile Driver", -- A voir
+    name = "Spinning Pile Driver", -- To be fixed : works only on one side
     memory_map = {
       {0x80,0x08},
       {0x81,0x01},
@@ -927,6 +1036,7 @@ character_specific.zangief.specials = {
     },
 	id = 0x02,
 	strength_set = 1,
+	reversal = true,
     input = {{}}, -- fixme
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -940,6 +1050,7 @@ character_specific.zangief.specials = {
     },
 	id = 0x04,
 	strength_set = 1,
+	reversal = true,
     input = {{"back"}}, -- fixme
     input_variations = {{"LK"}, {"MK"}, {"HK"}},
   },
@@ -951,6 +1062,7 @@ character_specific.zangief.specials = {
     },
 	id = 0x0A,
 	strength_set = 1,
+	reversal = true,
     input = { {"forward"}, {"forward", "down"}, {"down"} },
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   },
@@ -959,6 +1071,7 @@ character_specific.zangief.specials = {
     memory_map = {},
 	id = 0x00,
 	strength_set = 0,
+	reversal = true,
     input = {{}},
     input_variations = {{"LP","MP","HP"}, {"LK","MK","HK"}},
   },
@@ -967,6 +1080,7 @@ character_specific.zangief.specials = {
     memory_map = {},
 	id = 0x0,
 	strength_set = 0,
+	reversal = true,
     input = {{}},
     input_variations = {{"LP","MP","HP"}, {"LK","MK","HK"}},
   },
@@ -977,10 +1091,12 @@ character_specific.zangief.specials = {
     },
 	id = 0x08,
 	strength_set = 0,
+	reversal = true,
     input = {{}},
     input_variations = {{"LP"}, {"MP"}, {"HP"}},
   }
 }
+character_specific.zangief.throw = {"MP","HP","MK","HK"}
 ---------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------
 function determineStrengthValue(_variation, _strength_set)
@@ -1002,7 +1118,7 @@ function determineStrengthValue(_variation, _strength_set)
 	if _strength_set == 0 then
 			return 0x00
 	end
-	if _strength_set == -1 then -- Dhalsim TP
+	if _strength_set == -1 then -- Dhalsim TP or Boxer TAP
 		if _variation == "B+K" then
 			return 0x00
 		elseif _variation == "B+P" then
@@ -1011,10 +1127,38 @@ function determineStrengthValue(_variation, _strength_set)
 			return 0x04
 		elseif _variation == "F+K"then
 			return 0x06
+		--------------------------------
+		elseif _variation == "1" then
+			return 0x00
+		elseif _variation == "2" then
+			return 0x01
+		elseif _variation == "3" then
+			return 0x02
+		elseif _variation == "4" then
+			return 0x03
+		elseif _variation == "5" then
+			return 0x04
+		elseif _variation == "6" then
+			return 0x05
+		elseif _variation == "7" then
+			return 0x06
+		elseif _variation == "Final" then
+			return 0x07
 		end
 	end
 end
 
+function determineThrowInput(_throw)
+	if _throw == "MP" then
+		return "Medium Punch"
+	elseif _throw == "HP" then
+		return "Strong Punch"
+	elseif _throw == "MK" then
+		return "Medium Kick"
+	elseif _throw == "HK" then
+		return "Strong Kick"
+	end
+end
 function do_special_move (_input, _player_obj, _special, _variation)
   print(_special.name)
   for i, byte in pairs(_special.memory_map) do

--- a/games/ssf2xjr1/character_specific.lua
+++ b/games/ssf2xjr1/character_specific.lua
@@ -1,0 +1,1035 @@
+-----------------------------------------------------------------------------
+-- Made by McMic and Asunaro
+-----------------------------------------------------------------------------
+character_specific = {}
+characters =
+    {
+      "ryu",
+      "ehonda",
+      "blanka",
+      "guile",
+      "ken",
+      "chunli",
+      "zangief",
+      "dhalsim",
+      "dictator",
+      "sagat",
+      "boxer",
+      "claw",
+      "cammy",
+      "thawk",
+      "feilong",
+      "deejay",
+    }
+
+for i = 1, #characters do
+  character_specific[characters[i]] = { specials = {}}
+end
+------------------------------------------------------------------------------
+character_specific.blanka.specials = {
+  {
+    name = "Normal roll",
+    memory_map = {
+      {0xB9, 0x06}
+    },
+	id = 0x00,
+	strength_set = 1,
+    input = { {"back", "h_charge"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Vertical Roll",
+    memory_map = {
+      {0xB0, 0x06}
+    },
+	id = 0x04,
+	strength_set = 1,
+    input = { {"down", "h_charge"}, {"up"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Rainbow Roll",
+    memory_map = {
+      {0xB9, 0x06}
+    },
+	id = 0x06,
+	strength_set = 1,
+    input = { {"back", "h_charge"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Electric Thunder",
+    memory_map = {
+      -- We load all variations
+      {0x9A, 0x05},
+      {0x9C, 0x05},
+      {0x9E, 0x05}
+    },
+	id = 0x02,
+	strength_set = 1,
+    input = {{}},
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Forward Dash",
+    memory_map = {
+    },
+	id = 0x0A,
+	strength_set = 0,
+    input = { {"forward"} },
+    input_variations = {{"LK", "MK", "HK"}},
+  },
+  {
+    name = "Backward Dash",
+    memory_map = {
+    },
+	id = 0x0C,
+	strength_set = 0,
+    input = { {"back"} },
+    input_variations = {{"LK", "MK", "HK"}},
+  },
+  {
+    name = "Ground Shave Roll",
+    memory_map = {
+      {0xC1, 0x0A}
+    },
+	id = 0x08,
+	strength_set = 0,
+    input = { {"back", "h_charge"}, {"forward"}, {"back"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  }
+}
+----------------------------------------------------------------------------
+character_specific.boxer.specials = {
+	{
+    name = "Straight",
+    memory_map = {
+      {0x80, 0x08},
+      {0x88, 0x08},
+      {0xDD, 0x08},
+      {0xD6, 0x08}
+    },
+	id = 0x00,
+	strength_set = 1,
+    input = { {"back", "h_charge"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Upper Dash",
+    memory_map = {
+      {0x80, 0x08},
+      {0x88, 0x08},
+      {0xDD, 0x08},
+      {0xD6, 0x08}
+    },
+	id = 0x02,
+	strength_set = 1,
+    input = { {"back", "h_charge"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Buffalo Headbutt",
+    memory_map = {
+      {0xC0, 0x06}
+    },
+	id = 0x06,
+	strength_set = 1,
+    input = { {"down", "v_charge"}, {"up"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Ground Straight",
+    memory_map = {
+      {0x80, 0x06},
+      {0x88, 0x06},
+      {0xDD, 0x06},
+      {0xD6, 0x06}
+    },
+	id = 0x0A,
+	strength_set = 1,
+    input = { {"back", "h_charge"}, {"forward", "down"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Ground Upper",
+    memory_map = {
+      {0x80, 0x06},
+      {0x88, 0x06},
+      {0xDD, 0x06},
+      {0xD6, 0x06}
+    },
+	id = 0x0C,
+	strength_set = 1,
+    input = { {"back", "h_charge"}, {"forward", "down"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+   --~ 0001 - One
+  --~ 0121 - Two
+  --~ 0241 - Three
+  --~ 0481 - Four
+  --~ 0961 - Five
+  --~ 1441 - Six
+  --~ 1921 - Seven
+  --~ 2401 - Final
+  -- TAP is gonna be hard because it should be negative edge I guess
+  {
+   name = "TAP",
+   memory_map = {
+    {0xB6, 0001} -- A voir
+    },
+	id = 0x04,
+	strength_set = 0,
+    input = {{}},
+   input_variations = {{"LP", "MP", "HP"}},
+	},
+  --~ {
+    --~ name = "TAP Kick",
+    --~ memory_map = {
+      --~ {0xB8, 0001} -- A voir
+    --~ },
+    --~ input = {{}},
+    --~ input_variations = {{"LK", "MK", "HK"}},
+  --~ },
+  {
+    name = "Crazy Buffalo", -- Voir comment intégrer les différentes phases de la super ?
+    memory_map = {
+      {0xD4, 0x0A}
+    },
+	id = 0x08,
+	strength_set = 0,
+    input = { {"back", "h_charge"}, {"forward"}, {"back"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}, {"LK"}, {"MK"}, {"HK"}},
+  }
+}
+----------------------------------------------------------------------------
+character_specific.cammy.specials = {
+	{
+    name = "Cannon Spike",
+    memory_map = {
+      {0x92, 0x06}
+    },
+	id = 0x00,
+	strength_set = 2,
+    input = { {"forward"}, {"down"}, {"forward", "down"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Spiral Arrow",
+    memory_map = {
+      {0x96, 0x06}
+    },
+	id = 0x02,
+	strength_set = 2,
+    input = { {"down"}, {"forward", "down"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Spin Knuckle",
+    memory_map = {
+      {0xA2, 0x06}
+    },
+	id = 0x04,
+	strength_set = 2,
+    input = { {"back"}, {"back", "down"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Hooligan Combination", -- Compléter pour avoir les deux variations
+    memory_map = {
+      {0xA9, 0x06} -- buggy
+    },
+	id = 0x08,
+	strength_set = 2,
+    input = { {"back"}, {"down"}, {"forward", "down"}, {"up", "forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Spin Drive Smasher",
+    memory_map = {
+      {0xA6, 0x08}
+    },
+	id = 0x06,
+	strength_set = 0,
+    input = { {"down"}, {"forward", "down"}, {"forward"}, {"down"}, {"forward", "down"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  }
+}
+------------------------------------------------------------------------------
+character_specific.chunli.specials = {
+	{
+    name = "Spinning Bird Kick",
+    memory_map = {
+      {0xB0, 0x06}
+    },
+	id = 0x00,
+	strength_set = 2,
+    input = { {"back", "h_charge"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Hyakuretsu Kyaku",
+    memory_map = {
+      -- We load all variations
+      {0x9A, 0x05},
+      {0x9C, 0x05},
+      {0x9E, 0x05}
+    },
+	id = 0x02,
+	strength_set = 1,
+    input = {{}},
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Kikouken",
+    memory_map = {
+      {0x80, 0x06}, -- Ne fonctionne pas
+      {0x81, 0x00},
+      {0x82, 0x01},
+      {0x83, 0x01}
+    },
+	id = 0x04,
+	strength_set = 2,
+    input = { {"back", "h_charge"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Up Kicks",
+    memory_map = {
+      {0xBA, 0x06}
+    },
+	id = 0x06,
+	strength_set = 2,
+    input = { {"down", "h_charge"}, {"up"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Senretsu Kyaku",
+    memory_map = {
+      {0xBF, 0x0A}
+    },
+	id = 0x08,
+	strength_set = 0,
+    input = { {"back", "h_charge"}, {"forward"}, {"back"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  }
+}
+----------------------------------------------------------------------------------
+character_specific.claw.specials = {
+	{
+    name = "Crystal Flash",
+    memory_map = {
+      {0x88, 0x06}
+    },
+	id = 0x00,
+	strength_set = 2,
+    input = { {"back", "h_charge"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Wall Dive (Kick)",
+    memory_map = {
+      {0x8C, 0x06} -- broken
+    },
+	id = 0x02,
+	strength_set = 2,
+    input = { {"down", "h_charge"}, {"up"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Wall Dive (Punch)",
+    memory_map = {
+      {0x90, 0x06}
+    },
+	id = 0x06,
+	strength_set = 2,
+    input = { {"down", "h_charge"}, {"up"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Flip Kick",
+    memory_map = {
+      {0x9D, 0x06}
+    },
+	id = 0x0C,
+	strength_set = 2,
+    input = { {"down", "back", "h_charge"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Back Flip (Punch)",
+    memory_map = {},
+    input = {{}},
+	id = 0x04,
+	strength_set = 0,
+    input_variations = {{"LP", "MP", "HP"}},
+  },
+  {
+    name = "Back Flip (Kick)",
+    memory_map = {},
+    input = {{}},
+	id = 0x08,
+	strength_set = 0,
+    input_variations = {{"LK", "MK", "HK"}},
+  },
+  {
+    name = "Rolling Izuna Drop",
+    memory_map = {
+      {0x99, 0x0A}
+    },
+	id = 0x0A,
+	strength_set = 0,
+    input = { {"down", "h_charge"}, {"forward"}, {"back"}, {"up"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  }
+}
+---------------------------------------------------------------------------------
+character_specific.deejay.specials = {
+  {
+    name = "Sobat Kick",
+    memory_map = {
+      {0xA6, 0x06}
+    },
+	id = 0x00,
+	strength_set = 2,
+    input = { {"back", "h_charge"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Machine Gun Upper",
+    memory_map = {
+      {0xAB, 0x06}
+    },
+	id = 0x02,
+	strength_set = 2,
+    input = { {"down", "h_charge"}, {"up"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Air Slasher",
+    memory_map = {
+      {0x92, 0x06}
+    },
+	id = 0x04,
+	strength_set = 2,
+    input = { {"back", "h_charge"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Jack Knife",
+    memory_map = {
+      {0x96, 0x06}
+    },
+	id = 0x06,
+	strength_set = 2,
+    input = { {"down", "h_charge"}, {"up"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Sobat Carnival",
+    memory_map = {
+      {0xAF, 0x0A}
+    },
+	id = 0x08,
+	strength_set = 0,
+    input = { {"back", "h_charge"}, {"forward"}, {"back"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  }
+}
+--------------------------------------------------------------------------------
+character_specific.dhalsim.specials = {
+  {
+    name = "Yoga Fire",
+    memory_map = {
+      {0x80, 0x08}
+    },
+	id = 0x00,
+	strength_set = 2,
+    input = { {"down"}, {"forward", "down"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Yoga Flame",
+    memory_map = {
+      {0x9A, 0x04}
+    },
+	id = 0x02,
+	strength_set = 2,
+    input = { {"back"}, {"back", "down"}, {"down"}, {"forward", "down"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Yoga Blast",
+    memory_map = {
+      {0x84, 0x08}
+    },
+	id = 0x08,
+	strength_set = 2,
+    input = { {"back"}, {"forward", "down"}, {"down"}, { "forward", "down"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+   {
+    name = "Yoga Teleport", -- Modified to fit makeReversalSettingsButtons()
+    memory_map = {
+      {0xE0, 0x06}
+    },
+	id = 0x04,
+	strength_set = -1,
+    input_variations = {{"F+P"},{"F+K"},{"B+P"},{"B+K"}},
+  },
+  --{
+    --name = "Yoga Teleport (Forward)",
+    --memory_map = {
+     -- {0xE0, 0x06} -- Autre valeur à rajouter
+    --},
+	--id = 0x04,
+	--strength_set = 2,
+    --input = { {"forward"}, {"down"}, {"forward", "down"} },
+    --input_variations = {{"LP", "MP", "HP"},{"LK", "MK", "HK"}},
+  --},
+  --{
+   -- name = "Yoga Teleport (Back)",
+    --memory_map = {
+     -- {0xE0, 0x05} -- Autre valeur à rajouter
+    --},
+	--id = 0x04,
+	--strength_set = 2,
+    --input = { {"back"}, {"down"}, {"back", "down"} },
+    --input_variations = {{"LP", "MP", "HP"},{"LK", "MK", "HK"}},
+  --},
+  {
+    name = "Yoga Inferno",
+    memory_map = {
+      {0x96, 0x10}
+    },
+	id = 0x06,
+	strength_set = 0,
+    input = { {"back"},{"back", "down"},{"down"},{"forward", "down"},{"back"},{"back", "down"},{"down"},{"forward", "down"},{"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  }
+}
+--------------------------------------------------------------------------------------------------
+character_specific.dictator.specials = {
+  {
+    name = "Psycho Crusher",
+    memory_map = {
+      {0x80, 0x06}
+    },
+	id = 0x00,
+	strength_set = 1,
+    input = { {"back", "h_charge"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Scissor Kick",
+    memory_map = {
+      {0x88, 0x06}
+    },
+	id = 0x02,
+	strength_set = 1,
+    input = { {"back", "h_charge"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Head Stomp",
+    memory_map = {
+      {0x91, 0x06}
+    },
+	id = 0x04,
+	strength_set = 1,
+    input = { {"down", "h_charge"}, {"up"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Devil's Reverse",
+    memory_map = {
+      {0xAC, 0x06}
+    },
+	id = 0x06,
+	strength_set = 2,
+    input = { {"down", "h_charge"}, {"up"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Knee Press Knightmare",
+    memory_map = {
+      {0xC5, 0x0A}
+    },
+	id = 0x08,
+	strength_set = 0,
+    input = { {"back", "h_charge"}, {"forward"}, {"back"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  }
+}
+---------------------------------------------------------------------------------
+character_specific.feilong.specials = {
+  {
+    name = "Rekka", -- Should be tested if chained rekka works
+    memory_map = {
+      {0x90, 0x04},
+      {0xA0, 0x04}
+    },
+	id = 0x00,
+	strength_set = 2,
+    input = { {"down"}, {"down", "forward"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  --~ {
+    --~ name = "Rekka 2",
+    --~ memory_map = {
+      --~ {0xA0, 0x04}
+    --~ },
+    --~ input = { {"down"}, {"down", "forward"}, {"forward"} },
+    --~ input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  --~ },
+  {
+    name = "Flame Kick",
+    memory_map = {
+      {0x94, 0x04}
+    },
+	id = 0x02,
+	strength_set = 2,
+    input = { {"back"}, {"down"}, {"down", "back"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Chicken Wing", -- Seems buggy
+    memory_map = {
+      {0xB4, 0x06}
+    },
+	id = 0x06,
+	strength_set = 2,
+    input = { {"back"}, {"down"}, {"forward", "down"}, {"forward", "up"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}} -- only lk works
+  },
+  {
+    name = "Rekka Sinken",
+    memory_map = {
+      {0xB0, 0x0A}
+    },
+	id = 0x04,
+	strength_set = 0,
+     input = { {"down"}, {"down", "forward"}, {"forward"}, {"down"}, {"down", "forward"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  }
+}
+-------------------------------------------------------------------------------------------
+character_specific.guile.specials = {
+  {
+    name = "Sonic Boom",
+    memory_map = {
+      {0x80, 0x06}
+    },
+	id = 0x00,
+	strength_set = 1,
+    input = { {"back", "h_charge"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Flash Kick",
+    memory_map = {
+      {0x86, 0x06}
+    },
+	id = 0x02,
+	strength_set = 1,
+    input = { {"down", "v_charge"}, {"up"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Double Somersault",
+    memory_map = {
+      {0x94, 0x0A}
+    },
+	id = 0x04,
+	strength_set = 0,
+    input = { {"down", "v_charge"}, {"forward"}, {"back"}, {"up"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  }
+}
+----------------------------------------------------------------------
+character_specific.ehonda.specials = {
+  {
+    name = "Flying Headbutt",
+    memory_map = {
+      {0x88, 0x06}
+    },
+	id = 0x00,
+	strength_set = 2,
+     input = { {"back", "h_charge"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Hundred Hands Slap",
+    memory_map = {
+      -- We load all variations
+      {0xC6, 0x05},
+      {0xC8, 0x05},
+      {0xCA, 0x05}
+    },
+	id = 0x02,
+	strength_set = 2,
+    input = {{}},
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Butt Drop",
+    memory_map = {
+      {0x90, 0x06}
+    },
+	id = 0x04,
+	strength_set = 2,
+    input = { {"down", "h_charge"}, {"up"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Oichio Throw",
+    memory_map = {
+      {0x96, 0x06}
+    },
+	id = 0x08,
+	strength_set = 0,
+    input = { {"forward"}, {"forward", "down"}, {"down"}, {"back"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Double Headbutt", -- ne s'affiche pas
+    memory_map = {
+      {0x94, 0x0A}
+    },
+	id = 0x06,
+	strength_set = 0,
+    input = { {"back", "h_charge"}, {"forward"}, {"back"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  }
+}
+-----------------------------------------------------------------------
+character_specific.thawk.specials = {
+ {
+    name = "Tomahawk",
+    memory_map = {
+      {0x8D, 0x04}
+    },
+	id = 0x00,
+	strength_set = 2,
+	input = { {"forward"}, {"down"}, {"down", "forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Mexican Typhoon", -- A voir
+    memory_map = {
+      {0x91,0x04}, -- or 5 if other side
+      {0x92,0x06},
+      {0x93,0x08},
+      {0x94,0x00}
+    },
+	id = 0x04,
+	strength_set = 2,
+    input = {{"back"}}, -- fixme
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Double Typhoon", -- A voir
+    memory_map = {
+    },
+	id = 0x06,
+	strength_set = 0,
+    input = {{}},
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  }
+}
+--------------------------------------------------------------------
+character_specific.ken.specials = {
+  {
+    name = "Hadouken",
+    memory_map = {
+      {0x94, 0x04}
+    },
+	id = 0x00,
+	strength_set = 2,
+    input = { {"down"}, {"down", "forward"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Hurricane Kick",
+    memory_map = {
+      {0x90, 0x04}
+    },
+	id = 0x02,
+	strength_set = 2,
+    input = { {"down"}, {"down", "back"}, {"back"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Shoryuken",
+    memory_map = {
+      {0x98, 0x04}
+    },
+	id = 0x04,
+	strength_set = 2,
+    input = { {"forward"}, {"down"}, {"down", "forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Crazy Kick 1",
+    memory_map = {
+      {0xE6, 0x04}
+    },
+	id = 0x08,
+	strength_set = 0,
+    input = { {"down"}, {"down", "forward"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Crazy Kick 2",
+    memory_map = {
+      {0xE8, 0x04}
+    },
+	id = 0x0A,
+	strength_set = 0,
+    input = { {"forward"}, {"down", "forward"}, {"down"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Crazy Kick 3",
+    memory_map = {
+      {0xEA, 0x08}
+    },
+	id = 0x0C,
+	strength_set = 0,
+    input = { {"down"}, {"down", "forward"}, {"forward"}, {"down"}, {"down", "forward"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Shoryureppa",
+    memory_map = {
+      {0xA0, 0x08}
+    },
+	id = 0x06,
+	strength_set = 0,
+    input = { {"down"}, {"down", "forward"}, {"forward"}, {"down"}, {"down", "forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  }
+}
+----------------------------------------------------------------------
+character_specific.ryu.specials = {
+  {
+    name = "Hadouken",
+    memory_map = {
+      {0x94, 0x04}
+    },
+	id = 0x00,
+	strength_set = 2,
+    input = { {"down"}, {"down", "forward"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Hurricane Kick",
+    memory_map = {
+      {0x90, 0x04}
+    },
+	id = 0x02,
+	strength_set = 2,
+    input = { {"down"}, {"down", "back"}, {"back"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Shoryuken",
+    memory_map = {
+      {0x98, 0x04}
+    },
+	id = 0x04,
+	strength_set = 2,
+    input = { {"forward"}, {"down"}, {"down", "forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Red Hadouken",
+    memory_map = {
+      {0xE0, 0x08}
+    },
+	id = 0x06,
+	strength_set = 2,
+    input = { {"back"}, {"back", "forward"}, {"down"}, {"down", "forward"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Shinku Hadouken",
+    memory_map = {
+      {0xA0, 0x0A}
+    },
+	id = 0x08,
+	strength_set = 0,
+    input = { {"down"}, {"down", "forward"}, {"forward"}, {"down"}, {"down", "forward"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  }
+}
+----------------------------------------------------------------------------------------
+character_specific.sagat.specials = {
+  {
+    name = "Tiger Shot Up",
+    memory_map = {
+      {0x88, 0x06}
+    },
+	id = 0x00,
+	strength_set = 2,
+    input = { {"down"}, {"down", "forward"}, {"forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Tiger Shot Low",
+    memory_map = {
+      {0x8C, 0x06}
+    },
+	id = 0x04,
+	strength_set = 2,
+    input = { {"down"}, {"down", "forward"}, {"forward"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Tiger Uppercut",
+    memory_map = {
+      {0x80, 0x06}
+    },
+	id = 0x02,
+	strength_set = 2,
+   input = { {"forward"}, {"down"}, {"down", "forward"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Tiger Knee",
+    memory_map = {
+      {0x84, 0x06}
+    },
+	id = 0x06,
+	strength_set = 2,
+    input = { {"down"}, {"forward"}, {"forward", "up"} },
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+  {
+    name = "Tiger Genocide",
+    memory_map = {
+      {0x9E, 0x0A}
+    },
+	id = 0x08,
+	strength_set = 0,
+    input = { {"down"}, {"forward", "down"}, {"forward"}, {"down"}, {"forward", "down"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}, {"LK"}, {"MK"}, {"HK"}},
+  }
+}
+------------------------------------------------------------------------
+character_specific.zangief.specials = {
+  {
+    name = "Spinning Pile Driver", -- A voir
+    memory_map = {
+      {0x80,0x08},
+      {0x81,0x01},
+      {0x82,0x0E},
+      {0x83,0x00}
+    },
+	id = 0x02,
+	strength_set = 1,
+    input = {{}}, -- fixme
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Bear Grab",
+    memory_map = {
+      {0x9B,0x06},
+      {0x9C,0x06},
+      {0x9D,0x08},
+      {0x9E,0x00}
+    },
+	id = 0x04,
+	strength_set = 1,
+    input = {{"back"}}, -- fixme
+    input_variations = {{"LK"}, {"MK"}, {"HK"}},
+  },
+
+  {
+    name = "Banishing Flat",
+    memory_map = {
+      {0xB3, 0x06}
+    },
+	id = 0x0A,
+	strength_set = 1,
+    input = { {"forward"}, {"forward", "down"}, {"down"} },
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  },
+  {
+    name = "Lariat (Punch)",
+    memory_map = {},
+	id = 0x00,
+	strength_set = 0,
+    input = {{}},
+    input_variations = {{"LP","MP","HP"}, {"LK","MK","HK"}},
+  },
+   {
+    name = "Lariat (Kick)",
+    memory_map = {},
+	id = 0x0,
+	strength_set = 0,
+    input = {{}},
+    input_variations = {{"LP","MP","HP"}, {"LK","MK","HK"}},
+  },
+  {
+    name = "Final Atomic Buster", -- A voir
+    memory_map = {
+      -- TODO
+    },
+	id = 0x08,
+	strength_set = 0,
+    input = {{}},
+    input_variations = {{"LP"}, {"MP"}, {"HP"}},
+  }
+}
+---------------------------------------------------------------------------------
+---------------------------------------------------------------------------------
+function determineStrengthValue(_variation, _strength_set)
+	if _variation == "LP" or _variation == "LK" then
+			return 0x0
+	elseif _variation == "MP" or _variation == "MK" then
+		if _strength_set == 1 then
+			return 0x01
+		elseif _strength_set == 2 then
+			return 0x02
+		end
+	elseif _variation == "HP" or _variation == "HK" then
+		if _strength_set == 1 then
+			return 0x02
+		elseif _strength_set == 2 then
+			return 0x04
+		end
+	end
+	if _strength_set == 0 then
+			return 0x00
+	end
+	if _strength_set == -1 then -- Dhalsim TP
+		if _variation == "B+K" then
+			return 0x00
+		elseif _variation == "B+P" then
+			return 0x02
+		elseif _variation == "F+P"then
+			return 0x04
+		elseif _variation == "F+K"then
+			return 0x06
+		end
+	end
+end
+
+function do_special_move (_input, _player_obj, _special, _variation)
+  print(_special.name)
+  for i, byte in pairs(_special.memory_map) do
+    memory.writebyte(_player_obj.base + byte[1], byte[2])
+  end
+
+  -- Cancel all input
+  clear_player_input(_input, _player_obj.id, false)
+
+  for i, _move in pairs(_special.input[#_special.input]) do
+    _input[_player_obj.prefix .. " " .. sequence_input_to_key(_move, _player_obj.flip_input)] = true
+  end
+
+  for i, _move in pairs(_special.input_variations[_variation]) do
+    _input[_player_obj.prefix .. " " .. sequence_input_to_key(_move, _player_obj.flip_input)] = true
+  end
+end
+-------------------------------------------------------------------------------------------------

--- a/games/ssf2xjr1/guipages.lua
+++ b/games/ssf2xjr1/guipages.lua
@@ -62,30 +62,6 @@ guicustompage = {
 					end
 	},
 	{
-		text = "AutoReversal",
-		x = 8,
-		y = 60,
-		olcolour = "black",
-		info = {
-			"Control reversal on P2",
-			"Use the Replay Editor in the Recording menu to program the desired reversal action.",
-			"To improve auto-reversal select Game -> Load Game -> Apply IPS patches -> Play"
-		},
-		func =	function()
-				autoreversal_selector = autoreversal_selector + 1
-				if autoreversal_selector > 0 then
-					autoreversal_selector = -1
-				end
-			end,
-		autofunc = function(this)
-				if autoreversal_selector == -1 then
-					this.text = "AutoReversal (P2): Disabled"
-				elseif autoreversal_selector == 0 then
-					this.text = "AutoReversal (P2): Enabled"
-				end
-			end,
-	},
-	{
 		text = "AutoBlock",
 		x = 8,
 		y = 80,
@@ -144,3 +120,289 @@ guicustompage = {
 	},
 
 }
+
+-----------------------------------------------------------------------------------
+-- Added by Asunaro - Create a Reversal Settings Menu if the game has been patched
+-----------------------------------------------------------------------------------
+n = 0 -- count the number of reversal options
+reversal_options = {} -- Contains the buttons with the relevant informations from character_specific.lua
+
+function makeReversalSettingsButtons()
+	local character = readPlayerTwoCharacter()
+	n = 0
+	for i = 1, #character_specific[character].specials do
+		for k = 1, #character_specific[character].specials[i].input_variations do
+		 if (character_specific[character].specials[i].strength_set ~= 0) or (character_specific[character].specials[i].strength_set == 0 and k < 2) then -- Don't display variations for super moves or moves that don't have variations
+			n = n + 1
+			if k == 1 then
+				special_name = character_specific[character].specials[i].name
+				horizontal_length = 4
+			else
+				special_name = ""
+				if character_specific[character].specials[i].strength_set ~= -1 then -- Not Dhalsim TP
+					horizontal_length = 85 + 20*k
+				else -- Dhalsim TP
+					horizontal_length = 65 + 30*k
+				end
+			end
+			if character_specific[character].specials[i].strength_set == 0 then -- no variations
+				special_variation = ""
+			else
+				special_variation = character_specific[character].specials[i].input_variations[k][1]
+			end
+		reversal_options[n] = {
+				text = special_name.." "..special_variation,
+				x = horizontal_length,
+				y = 15 + 15*i,
+				--info = tostring(character_specific[character].specials[i].input) -- Maybe add move description
+				olcolour = "black",
+				fillpercent = 0,
+				checked = false,
+				special_id = {character_specific[character].specials[i].id, determineStrengthValue(character_specific[character].specials[i].input_variations[k][1], character_specific[character].specials[i].strength_set)},
+				func = function() end,
+				autofunc = function(this)
+						if this.checked then
+							this.fillpercent = 1
+						elseif not this.checked then
+							this.fillpercent = 0
+						end
+					end,
+			}
+		table.insert(guipages.reversalsettings, reversal_options[n])
+		end
+		end
+	end
+end
+
+function insertReversalSettingsFunctions() -- Maybe there's a cleaner way ?
+	local newfunction = nil
+	for i = 1, #reversal_options do
+		if i == 1 then
+		newfunction = function()
+				reversal_options[1].checked = not reversal_options[1].checked
+				end
+		elseif i == 2 then
+			newfunction = function()
+				reversal_options[2].checked = not reversal_options[2].checked
+				end
+		elseif i == 3 then
+			newfunction = function()
+				reversal_options[3].checked = not reversal_options[3].checked
+				end
+		elseif i == 4 then
+			newfunction = function()
+				reversal_options[4].checked = not reversal_options[4].checked
+				end
+		elseif i == 5 then
+			newfunction = function()
+				reversal_options[5].checked = not reversal_options[5].checked
+				end
+		elseif i == 6 then
+			newfunction = function()
+				reversal_options[6].checked = not reversal_options[6].checked
+				end
+		elseif i == 7 then
+			newfunction = function()
+				reversal_options[7].checked = not reversal_options[7].checked
+				end
+		elseif i == 8 then
+			newfunction = function()
+				reversal_options[8].checked = not reversal_options[8].checked
+				end
+		elseif i == 9 then
+			newfunction = function()
+				reversal_options[9].checked = not reversal_options[9].checked
+				end
+		elseif i == 10 then
+			newfunction = function()
+				reversal_options[10].checked = not reversal_options[10].checked
+				end
+		elseif i == 11 then
+			newfunction = function()
+				reversal_options[11].checked = not reversal_options[11].checked
+				end
+		elseif i == 12 then
+			newfunction = function()
+				reversal_options[12].checked = not reversal_options[12].checked
+				end
+		elseif i == 13 then
+			newfunction = function()
+				reversal_options[13].checked = not reversal_options[13].checked
+				end
+		elseif i == 14 then
+			newfunction = function()
+				reversal_options[14].checked = not reversal_options[14].checked
+				end
+		elseif i == 15 then
+			newfunction = function()
+				reversal_options[15].checked = not reversal_options[15].checked
+				end
+		elseif i == 16 then
+			newfunction = function()
+				reversal_options[16].checked = not reversal_options[16].checked
+				end
+		elseif i == 17 then
+			newfunction = function()
+				reversal_options[17].checked = not reversal_options[17].checked
+				end
+		elseif i == 18 then
+			newfunction = function()
+				reversal_options[18].checked = not reversal_options[18].checked
+				end
+		elseif i == 19 then
+			newfunction = function()
+				reversal_options[19].checked = not reversal_options[19].checked
+				end
+		elseif i == 20 then
+			newfunction = function()
+				reversal_options[20].checked = not reversal_options[20].checked
+				end
+		elseif i == 21 then
+			newfunction = function()
+				reversal_options[21].checked = not reversal_options[21].checked
+				end
+		elseif i == 22 then
+			newfunction = function()
+				reversal_options[22].checked = not reversal_options[22].checked
+				end
+		elseif i == 23 then
+			newfunction = function()
+				reversal_options[23].checked = not reversal_options[23].checked
+				end
+		elseif i == 24 then
+			newfunction = function()
+				reversal_options[24].checked = not reversal_options[24].checked
+				end
+		elseif i == 25 then
+			newfunction = function()
+				reversal_options[25].checked = not reversal_options[25].checked
+				end
+		end
+		reversal_options[i].func = newfunction
+	end
+end
+
+do_not_reversal = { -- If checked the dummy won't reversal, randomly
+				text = "Don't reversal",
+				x = 4, -- To be modified when custom_sequence will be fixed. Now the two buttons would overlap
+				y = 150,
+				olcolour = "black",
+				fillpercent = 0,
+				checked = false,
+				func =	function()
+						do_not_reversal.checked = not do_not_reversal.checked
+				end,
+			autofunc = function(this)
+					if this.checked then
+						this.fillpercent = 1
+					elseif not this.checked then
+						this.fillpercent = 0
+					end
+				end,
+			}
+table.insert(guipages.reversalsettings, do_not_reversal)
+
+custom_sequence = { -- to be added : would play a sequence define in the Replay Editor when the dummy goes out of blockstun/hitsun or lands on his feet
+				text = "Custom Sequence",
+				x = 4,
+				y = 150,
+				olcolour = "black",
+				fillpercent = 0,
+				checked = false,
+				func =	function()
+					custom_sequence.checked = not custom_sequence.checked
+					autoreversal_selector = autoreversal_selector + 1
+					if autoreversal_selector > 0 then
+						autoreversal_selector = -1
+					end
+				end,
+			autofunc = function(this)
+					if this.checked then
+						this.fillpercent = 1
+					elseif not this.checked then
+						this.fillpercent = 0
+					end
+				end,
+			}
+-- table.insert(guipages.reversalsettings, custom_sequence) -- to be added
+
+customPageConfiguration = { -- Two different buttons depending if the game has been patched or not
+	{
+		text = "AutoReversal",
+		x = 8,
+		y = 60,
+		olcolour = "black",
+		info = {
+			"Control reversal on P2",
+			"Use the Replay Editor in the Recording menu to program the desired reversal action.",
+			"To improve auto-reversal select Game -> Load Game -> Apply IPS patches -> Play"
+		},
+		func =	function()
+				autoreversal_selector = autoreversal_selector + 1
+				if autoreversal_selector > 0 then
+					autoreversal_selector = -1
+				end
+			end,
+		autofunc = function(this)
+				if autoreversal_selector == -1 then
+					this.text = "AutoReversal (P2): Disabled"
+				elseif autoreversal_selector == 0 then
+					this.text = "AutoReversal (P2): Enabled"
+				end
+			end,
+	},
+	{
+			text = "Select Reversal",
+			x = 8,
+			y = 60,
+			olcolour = "black",
+			info = {
+				"Control reversal on P2",
+			},
+			func = 	function() CIG("reversalsettings", 1) end, -- "reversalsettings" has been placed in "fbneo-training-mode/guipages.lua(l.588)", maybe there's a way to place it here ?
+	}
+}
+
+deleteReversalSettings = function()
+	for i = 1, #reversal_options do
+		table.remove(guipages.reversalsettings)
+		reversal_options[i] = nil
+	end
+end
+
+local patched = false
+local custom_page_setting = 0 -- custompage : 0 = not loaded yet, 1 = not patched configuration, 2 = patched configuration
+
+makeReversalSettings = function(_patched) -- Display "Select Reversal" if the game has been patched, else use the default "Autoreversal" option
+	patched = _patched
+	if not patched then
+		if custom_page_setting == 2 then
+			interactivegui.page = 1
+			interactivegui.selection = 1
+			deleteReversalSettings()
+			table.remove(guicustompage)
+		end
+		table.insert(guicustompage, customPageConfiguration[1])
+		custom_page_setting = 1
+	else
+		if custom_page_setting == 1 then
+			autoreversal_selector = -1
+			table.remove(guicustompage)
+		end
+		if custom_page_setting ~= 2 then
+		table.insert(guicustompage, customPageConfiguration[2])
+		end
+		makeReversalSettingsButtons()
+		insertReversalSettingsFunctions()
+		custom_page_setting = 2
+	end
+	formatGuiTables()
+end
+
+reloadReversalSettings = function()
+	interactivegui.page = 1
+	interactivegui.selection = 1
+	deleteReversalSettings()
+	makeReversalSettings(true)
+	formatGuiTables()
+end

--- a/games/ssf2xjr1/guipages.lua
+++ b/games/ssf2xjr1/guipages.lua
@@ -118,47 +118,92 @@ guicustompage = {
 				end
 			end,
 	},
-
 }
 
 -----------------------------------------------------------------------------------
 -- Added by Asunaro - Create a Reversal Settings Menu if the game has been patched
 -----------------------------------------------------------------------------------
-n = 0 -- count the number of reversal options
+-------------
+-- General
+-------------
+local n = 0 -- count the number of reversal options
+local s = 0 -- count the number of unique special moves a character can reversal
 reversal_options = {} -- Contains the buttons with the relevant informations from character_specific.lua
-
 function makeReversalSettingsButtons()
 	local character = readPlayerTwoCharacter()
 	n = 0
+	s = 0
+	-- Specials
 	for i = 1, #character_specific[character].specials do
-		for k = 1, #character_specific[character].specials[i].input_variations do
-		 if (character_specific[character].specials[i].strength_set ~= 0) or (character_specific[character].specials[i].strength_set == 0 and k < 2) then -- Don't display variations for super moves or moves that don't have variations
-			n = n + 1
-			if k == 1 then
-				special_name = character_specific[character].specials[i].name
-				horizontal_length = 4
-			else
-				special_name = ""
-				if character_specific[character].specials[i].strength_set ~= -1 then -- Not Dhalsim TP
-					horizontal_length = 85 + 20*k
-				else -- Dhalsim TP
-					horizontal_length = 65 + 30*k
+		if character_specific[character].specials[i].reversal then
+			s = s + 1
+			for k = 1, #character_specific[character].specials[i].input_variations do
+			 if (character_specific[character].specials[i].strength_set ~= 0) or (character_specific[character].specials[i].strength_set == 0 and k == 1) then -- Don't display variations for super moves or moves that don't have variations
+				n = n + 1
+				if k == 1 then
+					special_name = character_specific[character].specials[i].name
+					horizontal_length = 4
+				else
+					special_name = ""
+					if character_specific[character].specials[i].strength_set ~= -1 then -- Not Dhalsim TP not Boxer TAP
+						horizontal_length = 85 + 20*k
+					elseif character == "dhalsim" then -- Dhalsim TP
+						horizontal_length = 65 + 30*k
+					elseif character == "boxer" then   -- Boxer TAP
+						horizontal_length = 95 + 15*k
+					end
+				end
+				if character_specific[character].specials[i].strength_set == 0 then -- no variations
+					special_variation = ""
+				else
+					special_variation = character_specific[character].specials[i].input_variations[k][1]
+				end
+				vertical_length = 15 + 15*s
+				reversal_options[n] = {
+					text = special_name.." "..special_variation,
+					x = horizontal_length,
+					y = vertical_length,
+					--info = tostring(character_specific[character].specials[i].input) -- Maybe add move description
+					olcolour = "black",
+					fillpercent = 0,
+					checked = false,
+					reversal_id = {character_specific[character].specials[i].id, determineStrengthValue(character_specific[character].specials[i].input_variations[k][1], character_specific[character].specials[i].strength_set)},
+					func = function() end,
+					autofunc = function(this)
+							if this.checked then
+								this.fillpercent = 1
+							elseif not this.checked then
+								this.fillpercent = 0
+							end
+						end,
+				}
+				table.insert(guipages.reversalsettings, reversal_options[n])
 				end
 			end
-			if character_specific[character].specials[i].strength_set == 0 then -- no variations
-				special_variation = ""
+		end
+	end
+	-- Throws
+	for i = 1, #character_specific[character].throw do
+		n = n + 1
+			if i == 1 then
+				throw_name = "Throw "..character_specific[character].throw[i]
 			else
-				special_variation = character_specific[character].specials[i].input_variations[k][1]
+				throw_name = character_specific[character].throw[i]
+			end
+			if i > 1 then
+				horizontal_length = 11 + 17*i
+			else
+				horizontal_length = 4
 			end
 		reversal_options[n] = {
-				text = special_name.." "..special_variation,
+				text = throw_name,
 				x = horizontal_length,
-				y = 15 + 15*i,
+				y = vertical_length + 15,
 				--info = tostring(character_specific[character].specials[i].input) -- Maybe add move description
 				olcolour = "black",
 				fillpercent = 0,
 				checked = false,
-				special_id = {character_specific[character].specials[i].id, determineStrengthValue(character_specific[character].specials[i].input_variations[k][1], character_specific[character].specials[i].strength_set)},
+				reversal_id = {"throw",character_specific[character].throw[i]},
 				func = function() end,
 				autofunc = function(this)
 						if this.checked then
@@ -169,8 +214,6 @@ function makeReversalSettingsButtons()
 					end,
 			}
 		table.insert(guipages.reversalsettings, reversal_options[n])
-		end
-		end
 	end
 end
 
@@ -277,14 +320,26 @@ function insertReversalSettingsFunctions() -- Maybe there's a cleaner way ?
 			newfunction = function()
 				reversal_options[25].checked = not reversal_options[25].checked
 				end
+		elseif i == 26 then
+			newfunction = function()
+				reversal_options[26].checked = not reversal_options[26].checked
+				end
+		elseif i == 27 then
+			newfunction = function()
+				reversal_options[27].checked = not reversal_options[27].checked
+				end
+		elseif i == 28 then
+			newfunction = function()
+				reversal_options[28].checked = not reversal_options[28].checked
+				end
 		end
 		reversal_options[i].func = newfunction
 	end
 end
 
-do_not_reversal = { -- If checked the dummy won't reversal, randomly
+do_not_reversal = { -- If checked, the dummy won't reversal, randomly
 				text = "Don't reversal",
-				x = 4, -- To be modified when custom_sequence will be fixed. Now the two buttons would overlap
+				x = 4,
 				y = 150,
 				olcolour = "black",
 				fillpercent = 0,
@@ -302,21 +357,17 @@ do_not_reversal = { -- If checked the dummy won't reversal, randomly
 			}
 table.insert(guipages.reversalsettings, do_not_reversal)
 
-custom_sequence = { -- to be added : would play a sequence define in the Replay Editor when the dummy goes out of blockstun/hitsun or lands on his feet
+custom_sequence = { -- When the dummy goes out of blockstun/hitsun or lands on his feet,plays a sequence defined in the Replay Editor
 				text = "Custom Sequence",
-				x = 4,
+				x = 75,
 				y = 150,
 				olcolour = "black",
 				fillpercent = 0,
 				checked = false,
 				func =	function()
 					custom_sequence.checked = not custom_sequence.checked
-					autoreversal_selector = autoreversal_selector + 1
-					if autoreversal_selector > 0 then
-						autoreversal_selector = -1
-					end
-				end,
-			autofunc = function(this)
+					end,
+				autofunc = function(this)
 					if this.checked then
 						this.fillpercent = 1
 					elseif not this.checked then
@@ -324,9 +375,9 @@ custom_sequence = { -- to be added : would play a sequence define in the Replay 
 					end
 				end,
 			}
--- table.insert(guipages.reversalsettings, custom_sequence) -- to be added
+table.insert(guipages.reversalsettings, custom_sequence)
 
-customPageConfiguration = { -- Two different buttons depending if the game has been patched or not
+customPageConfiguration = { -- Two different buttons depending on whether the game has been patched or not
 	{
 		text = "AutoReversal",
 		x = 8,
@@ -359,15 +410,20 @@ customPageConfiguration = { -- Two different buttons depending if the game has b
 			info = {
 				"Control reversal on P2",
 			},
-			func = 	function() CIG("reversalsettings", 1) end, -- "reversalsettings" has been placed in "fbneo-training-mode/guipages.lua(l.588)", maybe there's a way to place it here ?
+			func = 	function() CIG("reversalsettings", 1) end, -- "reversalsettings" has been placed in "fbneo-training-mode/guipages.lua(l.588)", maybe there's a way to place it in this file ?
 	}
 }
 
+--------------------------
+-- Displaying the options
+--------------------------
 deleteReversalSettings = function()
 	for i = 1, #reversal_options do
 		table.remove(guipages.reversalsettings)
 		reversal_options[i] = nil
 	end
+	do_not_reversal.checked = false
+	custom_sequence.checked = false
 end
 
 local patched = false
@@ -376,7 +432,7 @@ local custom_page_setting = 0 -- custompage : 0 = not loaded yet, 1 = not patche
 makeReversalSettings = function(_patched) -- Display "Select Reversal" if the game has been patched, else use the default "Autoreversal" option
 	patched = _patched
 	if not patched then
-		if custom_page_setting == 2 then
+		if custom_page_setting == 2 then -- The game was previously patched : reinitialize the GUI
 			interactivegui.page = 1
 			interactivegui.selection = 1
 			deleteReversalSettings()
@@ -385,18 +441,18 @@ makeReversalSettings = function(_patched) -- Display "Select Reversal" if the ga
 		table.insert(guicustompage, customPageConfiguration[1])
 		custom_page_setting = 1
 	else
-		if custom_page_setting == 1 then
+		if custom_page_setting == 1 then -- The game wasn't patched previously : reinitialize the GUI
 			autoreversal_selector = -1
 			table.remove(guicustompage)
 		end
 		if custom_page_setting ~= 2 then
 		table.insert(guicustompage, customPageConfiguration[2])
 		end
+		custom_page_setting = 2
 		makeReversalSettingsButtons()
 		insertReversalSettingsFunctions()
-		custom_page_setting = 2
 	end
-	formatGuiTables()
+	formatGuiTables() -- Function defined in fbneo-training-mode/guipages.lua (l.875). Maybe there's a cleaner way to reload the tables ?
 end
 
 reloadReversalSettings = function()

--- a/games/ssf2xjr1/guipages.lua
+++ b/games/ssf2xjr1/guipages.lua
@@ -69,6 +69,7 @@ guicustompage = {
 		info = {
 			"Control reversal on P2",
 			"Use the Replay Editor in the Recording menu to program the desired reversal action."
+			"To improve auto-reversal select Game -> Load Game -> Apply IPS patches -> Play"
 		},
 		func =	function()
 				autoreversal_selector = autoreversal_selector + 1

--- a/games/ssf2xjr1/guipages.lua
+++ b/games/ssf2xjr1/guipages.lua
@@ -62,13 +62,39 @@ guicustompage = {
 					end
 	},
 	{
-		text = "AutoBlock",
+		text = "AutoReversal",
 		x = 8,
 		y = 60,
 		olcolour = "black",
 		info = {
+			"Control reversal on P2",
+			"Use the Replay Editor in the Recording menu to program the desired reversal action."
+		},
+		func =	function()
+				autoreversal_selector = autoreversal_selector + 1
+				if autoreversal_selector > 0 then
+					autoreversal_selector = -1
+				end
+			end,
+		autofunc = function(this)
+				if autoreversal_selector == -1 then
+					this.text = "AutoReversal (P2): Disabled"
+				elseif autoreversal_selector == 0 then
+					this.text = "AutoReversal (P2): Enabled"
+				end
+			end,
+	},
+	{
+		text = "AutoBlock",
+		x = 8,
+		y = 80,
+		olcolour = "black",
+		info = {
 			"Control guard / auto-block on P2",
-			"Can be Disabled, block everything, block only ground attacks, block auto or block random."
+			"Block everything: will guard any ground or jump attack",
+			"Block ground attacks: useful to practice combos that start with a jump-in",
+			"Block auto: Allow the first hit, block if you drop the combo",
+			"Block random: useful to practice hit-confirms"
 		},
 		func =	function()
 				autoblock_selector = autoblock_selector + 1
@@ -93,7 +119,7 @@ guicustompage = {
 	{
 		text = "Stun/Dizzy",
 		x = 8,
-		y = 80,
+		y = 100,
 		olcolour = "black",
 		info = {
 			"Control Stun/Dizzy",

--- a/games/ssf2xjr1/guipages.lua
+++ b/games/ssf2xjr1/guipages.lua
@@ -68,7 +68,7 @@ guicustompage = {
 		olcolour = "black",
 		info = {
 			"Control reversal on P2",
-			"Use the Replay Editor in the Recording menu to program the desired reversal action."
+			"Use the Replay Editor in the Recording menu to program the desired reversal action.",
 			"To improve auto-reversal select Game -> Load Game -> Apply IPS patches -> Play"
 		},
 		func =	function()

--- a/games/ssf2xjr1/ssf2xjr1.lua
+++ b/games/ssf2xjr1/ssf2xjr1.lua
@@ -339,7 +339,7 @@ local autoReversal = function()
 		else
 			wb(0xff85bb,0)
 			wb(0xff85b7,0)
-			if (p2action == 14 and prev_p2action == 14) or (p2action == 20 and prev_p2action == 20) then
+			if (p2action == 14 or prev_p2action == 14) or (p2action == 20 or prev_p2action == 20) then
 				wb(0xff89b7,1)
 				wb(0xff89bb,1)
 			else
@@ -353,7 +353,7 @@ local autoReversal = function()
 		return
 	end
 
-	local DEBUG=true
+	local DEBUG=false
 
 	local framesrecorded = #recording[recording.recordingslot]
 	if (framesrecorded < 1) then
@@ -373,7 +373,6 @@ local autoReversal = function()
 	end
 
 	local reversal_flag = rb(0xFF89B7)
-	local boxer_reversal_flag = rb(0xFF89BB)
 	local frameanimation = rb(0xff896b)
 	local onair = rb(0xff89cf)
 	local prev_framesleft = framesleft
@@ -390,7 +389,7 @@ local autoReversal = function()
 	if (p2action == 14 and prev_p2action == 14) or (p2action == 20 and prev_p2action == 20) then
 		numframes = numframes + 1
 		if was_frameskip then
-			if DEBUG then print ("FRAMESKIP @ "..numframes) end
+			-- if DEBUG then print ("FRAMESKIP @ "..numframes) end
 			numframes=numframes+1
 			if prev_framesleft - 1 == framesleft and framesleft > 1 then
 				framesleft = framesleft - 1
@@ -413,7 +412,7 @@ local autoReversal = function()
 			counter_for_wakeup_reversal = 0
 		end
 
-		if iswakeup and reversal_executed_at > 0 and reversal_executed_at + framesrecorded + 1 < numframes and framesrecorded < 5 then
+		if not autoreversal_patched and iswakeup and reversal_executed_at > 0 and reversal_executed_at + framesrecorded + 1 < numframes and framesrecorded < 5 then
 			if DEBUG then print ("!!! Previous reversal attempt failed, trying again...") end
 			framesleft_for_wakeup_reversal[0] = framesrecorded + 2
 			framesleft_for_wakeup_reversal[1] = framesrecorded + 1
@@ -436,6 +435,7 @@ local autoReversal = function()
 		end
 	end
 
+	-- local boxer_reversal_flag = rb(0xFF89BB)
 	-- if (DEBUG) and (p2action==14 or prev_p2action==14 or p2action==20 or prev_p2action==20) then print("p2action=" .. p2action .. " | numframes=" .. numframes .. " | onair="..onair.." | fa="..frameanimation.." | cfw="..counter_for_wakeup_reversal .. " | fl="..framesleft .. " | rf="..reversal_flag.." | brf="..boxer_reversal_flag) end
 
 	if not iswakeup and (p2action ~= 14 and prev_p2action == 14) then
@@ -558,7 +558,7 @@ local autoBlock = function()
 		return
 	end
 
-	local DEBUG=true
+	local DEBUG=false
 
 	-- neutral when opponent is neutral, crouching or landing
 	if (p1action == 0 or p1action == 2 or p1action==6) then

--- a/games/ssf2xjr1/ssf2xjr1.lua
+++ b/games/ssf2xjr1/ssf2xjr1.lua
@@ -75,20 +75,26 @@ translationtable = {
 gamedefaultconfig = {
 	hud = {
 		combotextx=178,
-		combotexty=49,
+		combotexty=48,
 		comboenabled=true,
-		p1healthx=34,
-		p1healthy=23,
+		p1healthx=17,
+		p1healthy=22,
 		p1healthenabled=true,
-		p2healthx=339,
-		p2healthy=23,
+		p2healthx=355,
+		p2healthy=22,
 		p2healthenabled=true,
 		p1meterx=82,
 		p1metery=207,
-		p1meterenabled=true,
+		p1meterenabled=false,
 		p2meterx=294,
 		p2metery=207,
-		p2meterenabled=true,
+		p2meterenabled=false,
+	},
+	inputs = {
+		iconsize=8,
+		framenumbersenabled=true,
+		scrollinginputxoffset={2,335},
+		scrollinginputyoffset={74,74},
 	},
 }
 

--- a/games/ssf2xjr1/ssf2xjr1.lua
+++ b/games/ssf2xjr1/ssf2xjr1.lua
@@ -283,6 +283,8 @@ local function reversalThrow(_throw)
 			reversal_throw_ready = true
 		elseif counter >= 0x90-0x03 and counter <= 0x90 then -- Strong
 			reversal_throw_ready = true
+		elseif iswakeup and counter == 0x6A then -- Red Hadouken
+			reversal_throw_ready = true
 		else
 			reversal_throw_ready = false
 		end
@@ -343,9 +345,10 @@ local function customSequence() -- Would need to be improved
 	local onair = rb(0xff89cf)
 		if onair == 255 then
 			iswakeup = true
+			recording.playback = false
 		end
 	end
-	if not iswakeup and p2_custom_sequence_ready then
+	if not iswakeup and p2_custom_sequence_ready and prev_p2action ~= 0x00 and p2action ~= 0x00 then
 		local counter = rb(p2_blockstun_hitstun_counter)
 		--print("prev_p2action : "..prev_p2action)
 		--print("curr_p2action : "..p2action)
@@ -369,6 +372,9 @@ local function customSequence() -- Would need to be improved
 		--print(" Reversal on Wakeup")
 		togglePlayBack(nil, {})
 		iswakeup = false
+	end
+	if recording.playback then
+		p2_custom_sequence_ready = false
 	end
 end
 -------------------

--- a/games/ssf2xjr1/ssf2xjr1.lua
+++ b/games/ssf2xjr1/ssf2xjr1.lua
@@ -133,6 +133,9 @@ function readPlayerOneHealth()
 end
 
 function writePlayerOneHealth(health)
+	if not combovars.p1.refillhealthenabled then
+		return
+	end
 	local refill = false
 	if readPlayerOneHealth() < 33 then
 		-- if health < 33 we refill regardless of the state
@@ -157,6 +160,9 @@ function readPlayerTwoHealth()
 end
 
 function writePlayerTwoHealth(health)
+	if not combovars.p2.refillhealthenabled then
+		return
+	end
 	local refill = false
 	if readPlayerTwoHealth() < 33 then
 		-- if health < 33 we refill regardless of the state
@@ -212,6 +218,13 @@ local infiniteTime = function()
 end
 
 local neverEnd = function()
+
+	if combovars.p2.refillhealthenabled and combovars.p2.instantrefillhealth then
+		p2_need_health_refill = true
+	end
+	if combovars.p1.refillhealthenabled and combovars.p1.instantrefillhealth then
+		p1_need_health_refill = true
+	end
 
 	if p2_need_health_refill then
 		writePlayerTwoHealth(p2maxhealth)

--- a/games/ssf2xjr1/ssf2xjr1.lua
+++ b/games/ssf2xjr1/ssf2xjr1.lua
@@ -318,7 +318,10 @@ local reversal_executed = false
 local reversal_executed_at = -1
 local framesleft = -1
 local reversal_guessed = 0
+local infotimeout = 900
 local autoReversal = function()
+
+	local DEBUG=false
 
 	-- check to see if we are running an IPS patched rom with the reversal flag overwrite NOP'd
 	-- unpatched: PATCH1: BE770F0C PATCH2: 0EEBF23E
@@ -350,19 +353,28 @@ local autoReversal = function()
 	end
 
 	if autoreversal_selector == -1 then
+		infotimeout = 900
 		return
 	end
 
-	local DEBUG=false
-
 	local framesrecorded = #recording[recording.recordingslot]
-	if (framesrecorded < 1) then
+	if infotimeout > 0 then infotimeout = infotimeout - 1 end
+	if (autoreversal_patched and framesrecorded < 1 and infotimeout > 0) then
+		gui.text(220,50,"Reversal action: last special")
+		gui.text(220,60,"performed by P2. Switch controls")
+		gui.text(220,70,"with 3 coin presses.")
+	end
+	if (autoreversal_patched and framesrecorded < 1) then
+		return
+	end
+	if (framesrecorded > 1 and framesrecorded <= 8 and infotimeout > 0) then
+		gui.text(220,50,"Reversal action: Recorded slot")
+	end
+	if (framesrecorded < 1 and not autoreversal_patched) then
 		gui.text(220,50,"Use the Replay Editor in the")
 		gui.text(220,60,"Recording menu (hold coin) to")
 		gui.text(220,70,"program the desired reversal action.")
-		if not autoreversal_patched then
-			gui.text(35,80,"To improve auto-reversal select Game -> Load Game -> Apply IPS patches -> Play")
-		end
+		gui.text(35,80,"To improve auto-reversal select Game -> Load Game -> Apply IPS patches -> Play")
 		return
 	end
 	if (framesrecorded > 8) then

--- a/games/ssf2xjr1/ssf2xjr1.lua
+++ b/games/ssf2xjr1/ssf2xjr1.lua
@@ -117,14 +117,8 @@ function readPatch()
 	--   patched: PATCH1: 734AABE4 PATCH2: 9BF781C3
 
 	previously_patched = currently_patched
-	local patch1 = memory.readdword(0x782a2)
-	if (patch1 == 0x734AABE4) then
-		patch2 = memory.readdword(0x8e94e)
-		if (patch2 == 0x9BF781C3) then
-			currently_patched = true
-		else
-			currently_patched = false
-		end
+	if memory.readdword(0x782a2) == 0x734AABE4 and memory.readdword(0x8e94e) == 0x9BF781C3 then
+		currently_patched = true
 	else
 		currently_patched = false
 	end
@@ -346,7 +340,19 @@ gamedefaultconfig = {
 		iconsize=8,
 		framenumbersenabled=true,
 		scrollinginputxoffset={2,335},
-		scrollinginputyoffset={90,90},
+		scrollinginputyoffset={95,95},
+	},
+	p1 = {
+		instantrefillhealth=false,
+		refillhealthenabled=true,
+		instantrefillmeter=true,
+		refillmeterenabled=true,
+	},
+	p2 = {
+		instantrefillhealth=false,
+		refillhealthenabled=true,
+		instantrefillmeter=true,
+		refillmeterenabled=true,
 	},
 }
 

--- a/guipages.lua
+++ b/guipages.lua
@@ -582,6 +582,24 @@ guipages = { -- interactiveguipages
 		},
 		guielements.hitboxstate,
 	},
+	------------------------------------------------
+	-- Asunaro : Not sure if i can put "reversalsettings" somewhere else
+	------------------------------------------------
+	reversalsettings = {
+		title = {
+			text = "Reversal Settings",
+			x = interactivegui.boxxlength/2 - 48,
+			y = 1,
+		},
+		{
+			text = "<",
+			olcolour = "black",
+			info = "Back",
+			func =	function() CIG(interactivegui.previouspage,1) end,
+		},
+	},
+	------------------------------------------------
+	------------------------------------------------
 }
 
 if scrollingInputReg then -- if scrolling-input-display.lua is loaded
@@ -854,6 +872,7 @@ guipages.playerrecording = createPopUpMenu(guipages[4], nil, nil, nil, playerrec
 	.
 --]]
 -- format the tables for better navigation and format the info to fit the screen better
+function formatGuiTables() -- Asunaro : Made a function out of this "do" to format "reversalsettings" and "guicustompage" (in games/ssf2xjr1/guipages.lua). Maybe there's a cleaner way ?
 do 
 	local tab, str, str2, r, b
 	local infomax = interactivegui.boxxlength/4
@@ -887,3 +906,6 @@ do
 		guipagesformatted[i] = guiTableFormatting(tab)
 	end
 end
+end
+
+formatGuiTables()


### PR DESCRIPTION
This includes 2 modes of auto-reversal:

1) Without patching the rom: works 95% of the time (the other 5% "learns" to be more accurate).

2) With a rom patch that doesn't clear the reversal flag, so the dummy will always perform a reversal 100% of the time. It also has a very nice menu were you can choose which reversal action the dummy will perform.
For 2, the IPS patches will be included inside Fightcade's FBNeo support folders in the next Fightcade update (due this week).

Method 1 is made by pof (@poliva)
Method 2 is made by Asunaro (@Asunarooo)